### PR TITLE
feat: 상세 공고 페이지 기능 추가

### DIFF
--- a/src/pages/noticedetail/index.tsx
+++ b/src/pages/noticedetail/index.tsx
@@ -21,9 +21,9 @@ const NoticeDetail = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const shop_id = searchParams.get('shop_id');
-  const { 
-    data: userData, 
-    isError: userError, 
+  const {
+    data: userData,
+    isError: userError,
     isLoading: userLoading,
   } = useUserQuery();
   const { setIsOpen, setIsClose, key, isOpen } = useModal();
@@ -62,20 +62,23 @@ const NoticeDetail = () => {
       if (key === 'profileAlert') {
         router.push('/mypage');
       }
-    }
+    },
   };
 
-  const modalHeader = key === 'profileAlert' ? (
-    <>
-      <Image src={cautionImg} alt="경고 표시" />내 프로필을 먼저 등록해 주세요.
-    </>
-  ) : key === 'applySuccess' ? (
-    <>
-      <Image src={checkImg} alt="체크 표시" />신청이 완료되었습니다.
-    </>
-  ) : null;
+  const modalHeader =
+    key === 'profileAlert' ? (
+      <>
+        <Image src={cautionImg} alt="경고 표시" />내 프로필을 먼저 등록해
+        주세요.
+      </>
+    ) : key === 'applySuccess' ? (
+      <>
+        <Image src={checkImg} alt="체크 표시" />
+        신청이 완료되었습니다.
+      </>
+    ) : null;
 
-    // if (userLoading || !shop_id) {
+  // if (userLoading || !shop_id) {
   //   return <p>Loading...</p>;
   // }
 
@@ -177,7 +180,10 @@ const NoticeDetail = () => {
                 />
               </div>
               <div style={{ width: '80px' }}>
-                <RedButton onClick={handleModal.confirmCancel} text="취소하기" />
+                <RedButton
+                  onClick={handleModal.confirmCancel}
+                  text="취소하기"
+                />
               </div>
             </>
           }


### PR DESCRIPTION
## 어떤 기능인가요?

> 모달 관련 로직
(modalheader는 스타일링 추가해서 ui 수정 예정)


## 작업 상세 내용

- [x] 신청하기' 버튼을 누르면 프로필 등록이 되어있지 않으면 ”내 프로필을 먼저 등록해 주세요.” alert 창이 나타나고 '확인' 버튼을 누르면 프로필 등록 페이지로 이동합니다. '신청하기' 버튼을 누르면 프로필 등록이 되어있으면 신청이 완료됩니다. (완료)

- [x] 이미 신청한 공고에서 '취소하기' 버튼을 클릭 했을때 “신청을 취소하시겠어요?” alert 창이 나타나고 '취소하기' 버튼을 누르면 지원이 취소가 되고 '취소하기' 버튼이 '신청하기' 버튼으로 바뀝니다. (완료)

- [x] 알바 테스트 아이디로 get 요청 확인 (완료)

- [ ] 최신 순으로 최대 6개까지 보입니다. 6개를 초과할 경우 가장 과거의 것이 보이지 않습니다. 최근에 본 공고를 위한 별도 api는 없습니다. 브라우저 저장소를 활용해 주세요. 
(로직까지 구현 → 목업 데이터 넣어서 확인 예정)


> 기능부터 마무리하고 ui 수정하면서 리팩토링 진행하겠습니다.
