### PR TITLE
fix: mypage create 오류 수정

### DIFF
--- a/src/pages/mypage/create/index.tsx
+++ b/src/pages/mypage/create/index.tsx
@@ -12,7 +12,7 @@ const CreateForm = () => {
         <S.ContentWrap>
           <>
             <S.MyPageHeader>내 프로필</S.MyPageHeader>
-            <RegistrationProfile />
+            <RegistrationProfile edit={false} />
           </>
         </S.ContentWrap>
       </S.Container>

--- a/src/pages/mypage/edit/index.tsx
+++ b/src/pages/mypage/edit/index.tsx
@@ -12,7 +12,7 @@ const EditForm = () => {
         <S.ContentWrap>
           <>
             <S.MyPageHeader>내 프로필</S.MyPageHeader>
-            <RegistrationProfile />
+            <RegistrationProfile edit />
           </>
         </S.ContentWrap>
       </S.Container>

--- a/src/widgets/registrationMyPage/ui/registrationProfile/RegistrationProfile.tsx
+++ b/src/widgets/registrationMyPage/ui/registrationProfile/RegistrationProfile.tsx
@@ -14,7 +14,11 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useUserQuery } from '@/models/user/useUserData';
 import { useUpdateUserState } from '@/models/user/useUpdateUserState';
 
-export const RegistrationProfile = () => {
+interface Props {
+  edit: boolean;
+}
+
+export const RegistrationProfile = ({ edit }: Props) => {
   const { name, phone, address, bio, setName, setPhone, setAddress, setBio } =
     useProfileData();
   const [error, setError] = useState(USER_FORM_ERRORS_INITIAL_VALUE);
@@ -27,12 +31,14 @@ export const RegistrationProfile = () => {
 
   const result = useUserValidation();
 
-  useUpdateUserState(isLoading, user_id!, router, item, {
-    setName,
-    setPhone,
-    setAddress,
-    setBio,
-  });
+  if (edit) {
+    useUpdateUserState(isLoading, user_id!, router, item, {
+      setName,
+      setPhone,
+      setAddress,
+      setBio,
+    });
+  }
 
   return (
     <>


### PR DESCRIPTION
## 어떤 기능인가요?

mypage/create로 이동 시 mypage로 리다이렉트 되는 현상 수정

원인: /mypage/create는 user_id 쿼리스트링이 존재하지 않기 때문에 useEffect의 리다이렉트 로직을 타게 됨.
해결: edit이라는 boolean 값을 props로 전달받아서 edit이 true일 경우에만 useEffect 로직을 타게끔 변경

## 작업 상세 내용

- [ ] TODO
- [ ] TODO
- [ ] TODO

## 테스트 방법 (선택)

> 리뷰어가 어떻게 볼 수 있나요?

## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

> 리뷰어가 확인할 수 있는 캡처가 있다면 추가해 주세요.

## 고민되거나 어려운 부분 (선택)

> 이거 중점으로 봐주세요 👀
